### PR TITLE
Handled edge case for get()

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Refer to [API documentation](https://arindas.github.io/generational-lru/generati
 This is a library crate. You may include it in your `Cargo.toml` as follows:
 ```toml
 [dependencies]
-generational-lru = "0.1.1"
+generational-lru = "0.1"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ use generational_lru::lrucache::{LRUCache, CacheError};
 let capacity = 5;
 
 let mut lru_cache = LRUCache::<i32, i32>::with_capacity(capacity);
-assert_eq!(lru_cache.get(&0), Err(CacheError::CacheMiss));
+assert_eq!(lru_cache.query(&0), Err(CacheError::CacheMiss));
 
 for ele in 0..capacity {
     let x = ele as i32;
@@ -21,20 +21,20 @@ for ele in 0..capacity {
 
 for ele in 0..capacity {
     let x = ele as i32;
-    assert_eq!(lru_cache.get(&x), Ok(&x));
+    assert_eq!(lru_cache.query(&x), Ok(&x));
 }
 
 let x = capacity as i32;
 assert!(lru_cache.insert(x, x).is_ok());
 
-assert_eq!(lru_cache.get(&x), Ok(&x));
+assert_eq!(lru_cache.query(&x), Ok(&x));
 
-assert_eq!(lru_cache.get(&0), Err(CacheError::CacheMiss));
+assert_eq!(lru_cache.query(&0), Err(CacheError::CacheMiss));
 
 let x = capacity as i32 / 2;
 assert_eq!(lru_cache.remove(&x), Ok(x));
 
-assert_eq!(lru_cache.get(&x), Err(CacheError::CacheMiss));
+assert_eq!(lru_cache.query(&x), Err(CacheError::CacheMiss));
 assert_eq!(lru_cache.remove(&x), Err(CacheError::CacheMiss));
 
 // zero capacity LRUCache is unusable


### PR DESCRIPTION
- Handled edge case for get: reposition block after query
- Renamed get() to query() since this is an impure fn
- Improved code coverage